### PR TITLE
Update version of SKO-GridPCULimitter to use new assemblies in Torch.

### DIFF
--- a/SKO-GridPCULimitter/Properties/AssemblyInfo.cs
+++ b/SKO-GridPCULimitter/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.2.0")]
+[assembly: AssemblyFileVersion("1.5.2.0")]

--- a/SKO-GridPCULimitter/manifest.xml
+++ b/SKO-GridPCULimitter/manifest.xml
@@ -4,5 +4,5 @@
 	<Name>SKO-GridPCULimiter</Name>
 	<Guid>589f0698-d9c2-4d7c-b4fb-64df67657fcd</Guid>
 	<Repository>None</Repository>
-	<Version>v1.5.1</Version>
+	<Version>v1.5.2</Version>
 </PluginManifest>


### PR DESCRIPTION
- Should fix issue with DoDamage as it compiles with the new assemblies of the game.